### PR TITLE
C++11: Use override instead of virtual keyword.

### DIFF
--- a/glib/glibmm/error.h
+++ b/glib/glibmm/error.h
@@ -38,7 +38,7 @@ public:
   Error(const Error& other);
   Error& operator=(const Error& other);
 
-  virtual ~Error() noexcept;
+  ~Error() noexcept override;
 
   GQuark domain() const;
   int code() const;


### PR DESCRIPTION
Use override instead of virtual keyword in destructor also.
