### PR TITLE
TimeoutSource timers fire too soon when clock changes

### DIFF
--- a/glib/glibmm/main.cc
+++ b/glib/glibmm/main.cc
@@ -1102,7 +1102,7 @@ TimeoutSource::connect(const sigc::slot<bool()>& slot)
 
 TimeoutSource::TimeoutSource(unsigned int interval) : interval_(interval)
 {
-  expiration_.assign_current_time();
+  time64_to_time_val(get_time(), expiration_);
   expiration_.add_milliseconds(std::min<unsigned long>(G_MAXLONG, interval_));
 }
 


### PR DESCRIPTION
The problem is that TimeoutSource constructor uses TimeVal
assign_current_time() method that calls glib g_get_current_time()
that internally uses gettimeofday() and is using offset from unix
epoch that changes as soon as NTP syncs the clock. For getting
current time it should use Source::get_time() like prepare(),
check() or dispatch() methods. This method uses glib g_source_get_time()
that internally uses monotonic clock and is not affected by NTP
adjusting current time.

Problem was detected on embedded device without real-time clock
with older glibmm 2.48.1, so timers triggering right after NTP synced time
was more obvious. When TimoutSource constructor was called it got
current time as some date in last year, but right after NTP synced clock
the check in TimeoutSource::check() used already adjusted date. Since
in that old version the deprecated get_current_time() was used then
both calls resolved to gettimeofday() call that returns seconds since 
unix epoch and as result NTP made a large adjustment. Timers as result
decided that they are expired and triggered immediately.

In latest glibmm the use of deprecated Source::get_current_time() is removed
in prepare(), check() and dispatch() methods. So they use goood monotonic
clock. But constructor of TimeoutSource() still uses the TimeVal::assign_current_time()
that returns offset from unix epoch and is subjected to adjustments by NTP.
It should use same monotonic clock as other methods to calculate the
expiry time.

One note to be careful is that glib g_source_get_time() expects that GSource->context
is not null (glib main loop is already created).  There is check:

g_return_val_if_fail (source->context != NULL, 0);

but in release builds it may be NOP and code will crash. So it is possible to
break users code that calls TimoutSource constructor before the glib main
loop is created. To not rely on debug settings in glib g_source_get_time()
we changed it to:

  if (source->context == NULL) {
    return g_get_monotonic_time ();
  }

Missing GSource->context is not critical for purposes of getting current time.
Glib just can't cache it.
